### PR TITLE
Let job script import additional modules under its path

### DIFF
--- a/mapreduce/job.py
+++ b/mapreduce/job.py
@@ -76,6 +76,8 @@ class Job:
         self._aws_key = config.aws_key
         self._aws_secret_key = config.aws_secret_key
         modulefd = open(config.job_script)
+        # let the job script import additional modules under its path
+        sys.path.append(os.path.dirname(config.job_script))
         ## Lifted from FileDriver.py in jydoop.
         self._job_module = imp.load_module("telemetry_job", modulefd, config.job_script, ('.py', 'U', 1))
 


### PR DESCRIPTION
When managing multiple job scripts, it's convenient to place common components inside a shared module. This commit lets a job script load these modules located inside the script's directory.
