### PR TITLE
Reduce resource usage in MapReduce framework

### DIFF
--- a/mapreduce/job.py
+++ b/mapreduce/job.py
@@ -90,12 +90,10 @@ class Job:
 
     def fetch_remotes(self, remotes):
         # TODO: fetch remotes inside Mappers, and process each one as it becomes available.
-        remote_names = [ r.name for r in remotes if r.remote ]
+        remote_names = ( r.name for r in remotes if r.remote )
 
         # TODO: check cache first.
         result = 0
-        if len(remote_names) == 0:
-            return result
 
         fetch_cwd = os.path.join(self._work_dir, "cache")
         if not os.path.isdir(fetch_cwd):


### PR DESCRIPTION
I've noticed MapReduce jobs using more memory than necessary, so I tried to fix some of the problems I found.

A lot of the commits are about closing files after they've been used.

The "Use generators when partitioning local and remote files" commit saves the most memory, reducing the per-Mapper RES of my sample job from 1.2GB to around 300MB. The problem was each Boto Key uses quite a bit of memory, and we were storing a bunch of Keys in a list for all the remote files. This list persists when Mapper processes are forked, and we end up with a lot of used memory. The commit gets rid of the list by using a generator.
