### PR TITLE
Chop off more of the long tail

### DIFF
--- a/mapreduce/addon_perf/addon_perf.py
+++ b/mapreduce/addon_perf/addon_perf.py
@@ -137,11 +137,6 @@ def map(k, d, v, cx):
           print "Value is false!", k, addonID, measure, details
           val = 0
         if measure.endswith('_MS'):
-          # sanity check the measure; drop the whole entry if the duration seems crazy
-          # twenty minutes is a long time to wait for startup...
-          if val > (20 * 60 * 1000):
-            print "Unusual", measure, "value", val, "in entry", k, addonID
-            return
           bucket = logBucket(val)
           result[measure] = {bucket: 1}
           send = True


### PR DESCRIPTION
Change minimum popularity from 1 in 50k to 1 in 10k, and stop throwing away "unusual" values. The client side has changed from Date.now() to Components.utils.now() so time interval data should become cleaner.
