### PR TITLE
Refresh histogram_tools.py on init.

### DIFF
--- a/provisioning/cloudformation/telemetry-server-stack.json
+++ b/provisioning/cloudformation/telemetry-server-stack.json
@@ -380,6 +380,10 @@
           "  # PI servers don't produce these logs, so delete the config:",
           "  rm /etc/heka.d/server.toml",
           "fi",
+          "# Refresh histogram_tools.py:",
+          "cd /home/ubuntu/telemetry-server/telemetry",
+          "rm -f histogram_tools.py",
+          "sudo -u ubuntu bash ../bin/get_histogram_tools.sh",
           { "Fn::Join": [ "", [
             "echo '{\"incoming_bucket\":\"", { "Ref": "IncomingBucketName" }, "\",",
             "\"incoming_queue\":\"", { "Ref": "IncomingQueueName" }, "\",",
@@ -563,6 +567,10 @@
           "  # PI servers don't produce these logs, so delete the config:",
           "  rm /etc/heka.d/server.toml",
           "fi",
+          "# Refresh histogram_tools.py:",
+          "cd /home/ubuntu/telemetry-server/telemetry",
+          "rm -f histogram_tools.py",
+          "sudo -u ubuntu bash ../bin/get_histogram_tools.sh",
           { "Fn::Join": [ "", [
             "echo '{\"incoming_bucket\":\"", { "Ref": "IncomingBucketName" }, "\",",
             "\"incoming_queue\":\"", { "Ref": "IncomingQueueName" }, "\",",


### PR DESCRIPTION
Update histogram_tools.py when a new ec2 instance is provisioned
for the 'process_incoming' groups. This avoids the need to generate
new AMIs when histogram_tools.py is updated.
