### PR TITLE
Add support for geoip on csv lists of IPs.

### DIFF
--- a/telemetry/convert.py
+++ b/telemetry/convert.py
@@ -58,11 +58,26 @@ class Converter:
 
     def get_geo_country(self, ip):
         country = None
-        if self._geoip:
-            try:
-                country = self._geoip.country(ip).country.iso_code
-            except AddressNotFoundError, e:
-                pass
+        err = None
+        if ip is not None and self._geoip:
+            for candidate in str(ip).split(","):
+                candidate = candidate.strip()
+                if candidate == "":
+                    continue
+                try:
+                    country = self._geoip.country(candidate).country.iso_code
+                except AddressNotFoundError, e:
+                    pass
+                except Exception, e:
+                    err = e
+
+                # Return the first known country.
+                if country is not None:
+                    return country
+
+        if err is not None:
+            raise err
+
         return country
 
     def map_value(self, histogram, val):
@@ -306,7 +321,7 @@ class Converter:
                 if pingType == "saved-session" or pingType == "main":
                     # This is a unified ping in the "main" ping format:
                     # https://ci.mozilla.org/job/mozilla-central-docs/Tree_Documentation/toolkit/components/telemetry/telemetry/main-ping.html
-                    json_payload = json_dict["payload"] 
+                    json_payload = json_dict["payload"]
                     if "info" not in json_payload:
                         raise ValueError("Unified " + pingType + " missing payload.info")
                     elif "histograms" not in json_payload:

--- a/telemetry/test_convert.py
+++ b/telemetry/test_convert.py
@@ -339,6 +339,42 @@ class ConvertTest(unittest.TestCase):
         # Firefox payloads should not be geocoded
         self.assertNotIn("geoCountry", converted["info"])
 
+    def test_csv_geo(self):
+        test_invalid = {
+            "bla": None,
+            "123": None,
+            "500.500.500.500": None,
+        }
+
+        test_valid = {
+            ",,,,": None,
+            "": None,
+            "8.8.8.8": "US",
+            "142.68.238.79": "CA",
+            "2001:4860:4860::8888": "US",
+            "127.0.0.1": None,
+            "127.0.0.1, 8.8.8.8": "US",
+            "127.0.0.1, 10.0.0.1": None,
+            "127.0.0.1, 8.8.8.8": "US",
+            "127.0.0.1, 142.68.238.79": "CA",
+            "8.8.8.8, 142.68.238.79": "US",
+            "142.68.238.79, 8.8.8.8": "CA",
+            "142.68.238.79 ,,127.0.0.1,, 8.8.8.8": "CA",
+        }
+
+        self.assertIs(ConvertTest.converter.get_geo_country(None), None)
+
+        for ip, expected_country in test_invalid.iteritems():
+            with self.assertRaises(ValueError):
+                ConvertTest.converter.get_geo_country(ip)
+
+        for ip, expected_country in test_valid.iteritems():
+            actual_country = ConvertTest.converter.get_geo_country(ip)
+            if expected_country is None:
+                self.assertIs(actual_country, None)
+            else:
+                self.assertEqual(actual_country, expected_country)
+
     def test_bad_payload_bogus_bucket_value(self):
         raw = self.get_payload("normal")
         raw["histograms"]["STARTUP_CRASH_DETECTED"]["values"][0] = "two"


### PR DESCRIPTION
This allows geoip lookups to continue to work behind multiple levels
of load balancers / proxies. This addresses the "tee server" issue here:
https://github.com/mozilla-services/data-pipeline/issues/17