### PR TITLE
Missed unified pings reporting os=Windows_NT instead of WINNT

### DIFF
--- a/telemetry/convert.py
+++ b/telemetry/convert.py
@@ -204,6 +204,10 @@ class Converter:
         info = json_dict["info"]
         self.add_info_fields(info, envFields, envFieldMap)
 
+        # WINNT is reported as Windows_NT in the unified ping
+        if info.get("OS") == "Windows_NT":
+            info["OS"] = "WINNT"
+
         adapters = None
         try:
             adapters = envFields["system"]["gfx"]["adapters"]


### PR DESCRIPTION
The Telemetry dashboard is showing a new OS named "Windows_NT" in addition to the old "WINNT". This fixes it.
We don't have to worry about analysis scripts dealing with two names for Windows, Telemetry is pretty messed up on Nightly 39 right now regardless of this issue.

Can you post a warning on the Telemetry twitter to not rely on the dashboards right now. Actually, can you put a big fat warning at the top of telemetry.mozilla.org?