### PR TITLE
Temporary workaround for histogram_tools.py change

### DIFF
--- a/bin/get_histogram_tools.sh
+++ b/bin/get_histogram_tools.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-wget -c http://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/histogram_tools.py -O histogram_tools.py
+# FIXME: external dependencies caused histogram_tools.py to fail on 'tip'
+#        after bug 968923. Fetching a specific revision temporarily.
+#wget -c http://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/histogram_tools.py -O histogram_tools.py
+wget -c http://hg.mozilla.org/mozilla-central/raw-file/72940b27aeaa/toolkit/components/telemetry/histogram_tools.py -O histogram_tools.py


### PR DESCRIPTION
histogram_tools.py had some external dependencies added in
bug 968923, this change fetches the specific version previous
to that patch landing.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1168409