### PR TITLE
Always use the latest version of histogram_tools.py.

### DIFF
--- a/bin/get_histogram_tools.sh
+++ b/bin/get_histogram_tools.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-# FIXME: external dependencies caused histogram_tools.py to fail on 'tip'
-#        after bug 968923. Fetching a specific revision temporarily.
-#wget -c http://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/histogram_tools.py -O histogram_tools.py
-wget -c http://hg.mozilla.org/mozilla-central/raw-file/72940b27aeaa/toolkit/components/telemetry/histogram_tools.py -O histogram_tools.py
+
+wget -c http://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/histogram_tools.py -O histogram_tools.py


### PR DESCRIPTION
Using histogram_tools.py outside the mozilla-central tree, originally broken in [bug 968923](https://bugzilla.mozilla.org/show_bug.cgi?id=968923), is now fixed as [bug 1168409](https://bugzilla.mozilla.org/show_bug.cgi?id=1168409) has been resolved.