### PR TITLE
Standardize tags for accounting purposes

### DIFF
--- a/http/analysis-service/analysis-service-stack.yaml
+++ b/http/analysis-service/analysis-service-stack.yaml
@@ -287,6 +287,8 @@ Resources:
         - {Ref: AnalysisLoadBalancer}
       Tags:
         - {Key: Name, Value: analysis.telemetry.mozilla.org, PropagateAtLaunch: true}
+        - {Key: App, Value: pipeline, PropagateAtLaunch: true}
+        - {Key: Type, Value: telemetry-analysis-dashboard, PropagateAtLaunch: true}
     # Support Rolling updates if/when we roll out changes
     UpdatePolicy:
         AutoScalingRollingUpdate:

--- a/http/analysis-service/config.py
+++ b/http/analysis-service/config.py
@@ -20,7 +20,8 @@ SPARK_EMR_BUCKET = 'example'
 EPHEMERAL_MAP      = { "/dev/xvdb": "ephemeral0", "/dev/xvdc": "ephemeral1" }
 SECURITY_GROUPS    = []
 INSTANCE_PROFILE   = 'telemetry-analysis-profile'
-INSTANCE_APP_TAG   = 'telemetry-analysis-worker-instance'
+INSTANCE_APP_TAG   = 'pipeline'
+INSTANCE_TYPE_TAG   = 'telemetry-analysis-worker-instance'
 EMAIL_SOURCE       = 'telemetry-alerts@mozilla.com'
 
 # Buckets for storing S3 data

--- a/http/analysis-service/jobs/run.sh
+++ b/http/analysis-service/jobs/run.sh
@@ -25,6 +25,7 @@ if [ "$(jq -r '.num_workers|type' < $JOB_CONFIG)" == "number" ]; then # Spark cl
     SSH_KEY=$(jq -r '.ssl_key_name' < "$JOB_CONFIG")
     OWNER=$(jq -r '.owner' < "$JOB_CONFIG")
     APP_TAG=$(jq -r '.application_tag' < "$JOB_CONFIG")
+    TYPE_TAG=$(jq -r '.type_tag' < "$JOB_CONFIG")
     INSTANCE_PROFILE=$(jq -r '.spark_instance_profile' < "$JOB_CONFIG")
     EMR_BUCKET=$(jq -r '.spark_emr_bucket' < "$JOB_CONFIG")
     SUBMIT_ARGS=$(jq -r '.commandline' < "$JOB_CONFIG")

--- a/http/analysis-service/server.py
+++ b/http/analysis-service/server.py
@@ -235,7 +235,8 @@ def build_config(job):
             "name": "telemetry-analysis-{0}".format(job['name']),
             "default_tags": {
                 "Owner": "mreid@mozilla.com",
-                "Application": "telemetry-server"
+                "App": "pipeline",
+                "Type": "telemetry-server"
             },
             "ephemeral_map": {
                 "/dev/xvdb": "ephemeral0",
@@ -882,7 +883,8 @@ def spawn_worker_instance():
     ec2.create_tags([instance.id], {
         "Owner":            current_user.email,
         "Name":             request.form['name'],
-        "Application":      app.config['INSTANCE_APP_TAG']
+        "App":              app.config['INSTANCE_APP_TAG'],
+        "Type":             app.config['INSTANCE_TYPE_TAG']
     })
 
     # Send an email to the user who launched it
@@ -1028,7 +1030,8 @@ def cluster_spawn():
     emr.add_tags(jobflow_id, {
         "Owner": current_user.email,
         "Name": request.form['name'],
-        "Application": app.config['INSTANCE_APP_TAG']
+        "App": app.config['INSTANCE_APP_TAG'],
+        "Type": app.config['INSTANCE_TYPE_TAG']
     })
 
     # Send an email to the user who launched it

--- a/http/analysis-service/terminate-expired-instances.py
+++ b/http/analysis-service/terminate-expired-instances.py
@@ -11,7 +11,8 @@ ses = ses_connect(config.AWS_REGION)
 
 def main():
     reservations = ec2.get_all_reservations(
-        filters = {'tag:Application':  config.INSTANCE_APP_TAG}
+        filters = {'tag:App': config.INSTANCE_APP_TAG,
+                   'tag:Type': config.INSTANCE_TYPE_TAG}
     )
     for reservation in reservations:
         for instance in reservation.instances:

--- a/provisioning/ansible/playbooks/route53.yml
+++ b/provisioning/ansible/playbooks/route53.yml
@@ -18,7 +18,8 @@
           AnalysisPublicCDNDomainName: "{{resources_cfn.stack_outputs.AnalysisPublicCDNDomainName}}"
           AnalysisPublicDomainName: "{{public_analysis_dns_name}}"
         tags:
-          App: "telemetry"
+          App: "pipeline"
+          Type: "telemetry-analysis-dashboard"
           Env: "{{env}}"
           Stack: "{{stack_name}}"
       register: promote

--- a/provisioning/aws/aws_incoming.example.json
+++ b/provisioning/aws/aws_incoming.example.json
@@ -16,6 +16,7 @@
   "name": "mreid-telemetry-process-incoming-test",
   "default_tags": {
     "Owner": "mreid",
-    "Application": "telemetry-server"
+    "App": "pipeline",
+    "Type": "telemetry-server"
   }
 }

--- a/provisioning/aws/aws_incoming.prod.json
+++ b/provisioning/aws/aws_incoming.prod.json
@@ -17,7 +17,8 @@
   "name": "telemetry-process-incoming-v1-1",
   "default_tags": {
     "Owner": "mreid",
-    "Application": "telemetry-server"
+    "App": "pipeline",
+    "Type": "telemetry-server"
   },
   "ephemeral_map": {
     "/dev/xvdb": "ephemeral0",

--- a/provisioning/aws/aws_launcher.py
+++ b/provisioning/aws/aws_launcher.py
@@ -188,7 +188,7 @@ class Launcher(object):
         if len(default_tags) > 0:
             self.conn.create_tags([instance.id], default_tags)
         # TODO:
-        # - find all instances where Owner = mreid and Application = telemetry-server
+        # - find all instances where Owner = mreid and App = pipeline and Type =~ telemetry
         # - get the highest number
         # - use the next one (or first unused one) for the current instance name.
         name_tag = {"Name": self.config["name"]}

--- a/provisioning/aws/aws_telemetry_server_config.example.json
+++ b/provisioning/aws/aws_telemetry_server_config.example.json
@@ -15,7 +15,8 @@
   "process_incoming_config": "./aws_incoming.example.json",
   "default_tags": {
     "Owner": "mreid",
-    "Application": "telemetry-server"
+    "App": "pipeline",
+    "Type": "telemetry-server"
   },
   "skip_termination": true,
   "ephemeral_map": {

--- a/provisioning/aws/aws_telemetry_server_config.prod.json
+++ b/provisioning/aws/aws_telemetry_server_config.prod.json
@@ -17,7 +17,8 @@
   "primary_server": true,
   "default_tags": {
     "Owner": "mreid",
-    "Application": "telemetry-server"
+    "App": "pipeline",
+    "Type": "telemetry-server"
   },
   "skip_termination": true
 }

--- a/provisioning/aws/aws_telemetry_server_config.prod_secondary.json
+++ b/provisioning/aws/aws_telemetry_server_config.prod_secondary.json
@@ -17,7 +17,8 @@
   "primary_server": false,
   "default_tags": {
     "Owner": "mreid",
-    "Application": "telemetry-server"
+    "App": "pipeline",
+    "Type": "telemetry-server"
   },
   "skip_termination": true
 }

--- a/provisioning/aws/aws_util.py
+++ b/provisioning/aws/aws_util.py
@@ -76,7 +76,7 @@ def create_instance(config, aws_key=None, aws_secret_key=None):
     if len(default_tags) > 0:
         conn.create_tags([instance.id], default_tags)
     # TODO:
-    # - find all instances where Owner = mreid and Application = telemetry-server
+    # - find all instances where Owner = mreid and App = pipeline and Type =~ telemetry
     # - get the highest number
     # - use the next one (or first unused one) for the current instance name.
     name_tag = {"Name": config["name"]}

--- a/provisioning/aws/telemetry_server_base.hvm.json
+++ b/provisioning/aws/telemetry_server_base.hvm.json
@@ -13,7 +13,8 @@
   "name": "telemetry-server-base-hvm",
   "default_tags": {
     "Owner": "mreid",
-    "Application": "telemetry-server"
+    "App": "pipeline",
+    "Type": "telemetry-server"
   },
   "add_aws_credentials": true,
   "skip_termination": true

--- a/provisioning/aws/telemetry_server_base.pv.json
+++ b/provisioning/aws/telemetry_server_base.pv.json
@@ -13,7 +13,8 @@
   "name": "telemetry-server-base-pv",
   "default_tags": {
     "Owner": "mreid",
-    "Application": "telemetry-server"
+    "App": "pipeline",
+    "Type": "telemetry-server"
   },
   "add_aws_credentials": true,
   "skip_termination": true

--- a/provisioning/aws/telemetry_worker.hvm.json
+++ b/provisioning/aws/telemetry_worker.hvm.json
@@ -14,7 +14,8 @@
   "name": "telemetry-worker-hvm",
   "default_tags": {
     "Owner": "mreid",
-    "Application": "telemetry-server"
+    "App": "pipeline",
+    "Type": "telemetry-server"
   },
   "skip_termination": true
 }

--- a/provisioning/cloudformation/telemetry-regression-alerts.json
+++ b/provisioning/cloudformation/telemetry-regression-alerts.json
@@ -35,7 +35,8 @@
         "MaxSize":                 "1",
         "LoadBalancerNames":       [ { "Ref": "LoadBalancer" } ],
         "Tags": [
-          { "Key": "Application", "Value": "telemetry-server",              "PropagateAtLaunch": true },
+          { "Key": "App",         "Value": "pipeline",                      "PropagateAtLaunch": true },
+          { "Key": "Type",        "Value": "telemetry-regression-alerts",   "PropagateAtLaunch": true },
           { "Key": "Name",        "Value": "telemetry-regression-alerts",   "PropagateAtLaunch": true },
           { "Key": "Owner",       "Value": { "Ref": "SSHKeyName" },         "PropagateAtLaunch": true }
         ]

--- a/provisioning/cloudformation/telemetry-server-stack.json
+++ b/provisioning/cloudformation/telemetry-server-stack.json
@@ -77,7 +77,8 @@
           ]
         },
         "Tags": [
-          { "Key": "Application", "Value": "telemetry-server",      "PropagateAtLaunch": true },
+          { "Key": "App",         "Value": "pipeline",              "PropagateAtLaunch": true },
+          { "Key": "Type",        "Value": "telemetry-webserver",   "PropagateAtLaunch": true },
           { "Key": "Name",        "Value": "telemetry-webserver",   "PropagateAtLaunch": true },
           { "Key": "Owner",       "Value": { "Ref": "SSHKeyName" }, "PropagateAtLaunch": true }
         ]
@@ -196,7 +197,8 @@
           ]
         },
         "Tags": [
-          { "Key": "Application", "Value": "telemetry-server",           "PropagateAtLaunch": true },
+          { "Key": "App",         "Value": "pipeline",                   "PropagateAtLaunch": true },
+          { "Key": "Type",        "Value": "telemetry-process-incoming", "PropagateAtLaunch": true },
           { "Key": "Name",        "Value": "telemetry-process-incoming", "PropagateAtLaunch": true },
           { "Key": "Owner",       "Value": { "Ref": "SSHKeyName" },      "PropagateAtLaunch": true }
         ]
@@ -277,7 +279,8 @@
           ]
         },
         "Tags": [
-          { "Key": "Application", "Value": "telemetry-server",                      "PropagateAtLaunch": true },
+          { "Key": "App",         "Value": "pipeline",                              "PropagateAtLaunch": true },
+          { "Key": "Type",        "Value": "telemetry-process-incoming-overflow-1", "PropagateAtLaunch": true },
           { "Key": "Name",        "Value": "telemetry-process-incoming-overflow-1", "PropagateAtLaunch": true },
           { "Key": "Owner",       "Value": { "Ref": "SSHKeyName" },                 "PropagateAtLaunch": true }
         ]


### PR DESCRIPTION
`App` and `Type` are the tags we use for accounting. We're going to use `pipeline` as the `App` for anything related to the data pipeline, and use `Type` to further match specific applications such as telemetry. This is mostly important so that we can keep track of analysis worker costs.

Aside: I saw some tag weirdness to the effect of

```
Owner="NAME@mozilla.com Application=telemetry-analysis-worker-instance"
```

in dev so I have a suspicion that `--tags "Owner=$OWNER App=$APP_TAG Type=$TYPE_TAG"` might need to be escaped in some fashion in some cases.
