### PR TITLE
Allow code tarballs up to 100MB in size.

### DIFF
--- a/http/analysis-service/analysis-service-stack.yaml
+++ b/http/analysis-service/analysis-service-stack.yaml
@@ -252,6 +252,7 @@ Resources:
               "echo 'server {' > /etc/nginx/sites-enabled/default\n",
               "echo '        listen 80;' >> /etc/nginx/sites-enabled/default\n",
               "echo '        server_name analysisservice;' >> /etc/nginx/sites-enabled/default\n",
+              "echo '        client_max_body_size 100m;' >> /etc/nginx/sites-enabled/default\n",
               "echo '        location / { try_files $uri @analysisservice; }' >> /etc/nginx/sites-enabled/default\n",
               "echo '        location @analysisservice {' >> /etc/nginx/sites-enabled/default\n",
               "echo '                include uwsgi_params;' >> /etc/nginx/sites-enabled/default\n",

--- a/http/analysis-service/analysis-service-stack.yaml
+++ b/http/analysis-service/analysis-service-stack.yaml
@@ -252,7 +252,7 @@ Resources:
               "echo 'server {' > /etc/nginx/sites-enabled/default\n",
               "echo '        listen 80;' >> /etc/nginx/sites-enabled/default\n",
               "echo '        server_name analysisservice;' >> /etc/nginx/sites-enabled/default\n",
-              "echo '        client_max_body_size 100m;' >> /etc/nginx/sites-enabled/default\n",
+              "echo '        client_max_body_size 500m;' >> /etc/nginx/sites-enabled/default\n",
               "echo '        location / { try_files $uri @analysisservice; }' >> /etc/nginx/sites-enabled/default\n",
               "echo '        location @analysisservice {' >> /etc/nginx/sites-enabled/default\n",
               "echo '                include uwsgi_params;' >> /etc/nginx/sites-enabled/default\n",


### PR DESCRIPTION
Default for nginx is 1MB, which doesn't allow enough room for, say,
a heka build.