### PR TITLE
Get a specific revision of histogram_tools.py

### DIFF
--- a/bin/get_histogram_tools.sh
+++ b/bin/get_histogram_tools.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-wget -c http://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/histogram_tools.py -O histogram_tools.py
+wget -c http://hg.mozilla.org/mozilla-central/raw-file/6dc53d54f027/toolkit/components/telemetry/histogram_tools.py -O histogram_tools.py


### PR DESCRIPTION
We need to allow the 'extended_statitics_ok' field for historic
Histograms.json compatibility. It was removed in [Bug 1201492](https://bugzilla.mozilla.org/show_bug.cgi?id=1201492).