### PR TITLE
Fix an escaping error.

### DIFF
--- a/provisioning/aws/launch_worker.py
+++ b/provisioning/aws/launch_worker.py
@@ -71,7 +71,7 @@ tar xzvf code.tar.gz
 set +e
 echo "Beginning job $JOB_NAME ..." >> "$LOG"
 $MAIN &>> "$LOG"
-JOB_EXIT_CODE=$?
+JOB_EXIT_CODE=\$?
 echo "Finished job $JOB_NAME" >> "$LOG"
 set -e
 echo "'$MAIN' exited with code \$JOB_EXIT_CODE" >> "$LOG"


### PR DESCRIPTION
Without this one-character change, we're checking the exit code of
the invoking shell (the `chown` command, which presumably 
succeeds), not the shell running the command.