### PR TITLE
Allow for user specific cluster max workers

### DIFF
--- a/http/analysis-service/user.py
+++ b/http/analysis-service/user.py
@@ -1,6 +1,7 @@
 from flask.ext.login import UserMixin, AnonymousUserMixin
 
 class User(UserMixin):
+    _quotas = None
     def __init__(self, email):
         self.email = email
 
@@ -18,6 +19,15 @@ class User(UserMixin):
 
     def get_id(self):
         return self.email
+
+    def get_max_workers(self,dflt):
+        return _quotas['users'].get(self.email,dflt)
+
+    def is_worker_count_valid(self,asked,dflt):
+        if asked > _quotas['users'].get(self.email, dflt) or asked <=0:
+            return False
+        else:
+            return True
 
 class AnonymousUser(AnonymousUserMixin):
     def is_authorized(self):

--- a/http/analysis-service/userquota.py
+++ b/http/analysis-service/userquota.py
@@ -1,0 +1,6 @@
+quotas = {
+        'users': {
+          "biswas@mozilla.com" : 200,
+          "heathcliff@mozilla.com" : 500
+          }
+}


### PR DESCRIPTION
The idea is to allow for users who are in a white list to create larger sized clusters. Also tag the clusters with the user id so that accounting can be done.
- Added a file 'userquota.py' that contains user specific worker counts.
- Modified user.py to return functions that specify if the requested count is legal  and what the max count is
- Modified server.py to use user specific worker counts and tag clusters with user name for accounting
