### PR TITLE
Add "App" and "Type" tags used for accounting

### DIFF
--- a/http/analysis-service/config.py
+++ b/http/analysis-service/config.py
@@ -23,6 +23,10 @@ INSTANCE_PROFILE   = 'telemetry-analysis-profile'
 INSTANCE_APP_TAG   = 'telemetry-analysis-worker-instance'
 EMAIL_SOURCE       = 'telemetry-alerts@mozilla.com'
 
+# Tags for accounting purposes
+ACCOUNTING_APP_TAG  = 'telemetry-analysis'
+ACCOUNTING_TYPE_TAG = 'worker'
+
 # Buckets for storing S3 data
 TEMPORARY_BUCKET   = 'bucket-for-ssh-keys'
 CODE_BUCKET        = 'telemetry-analysis-code-2'

--- a/http/analysis-service/server.py
+++ b/http/analysis-service/server.py
@@ -882,7 +882,9 @@ def spawn_worker_instance():
     ec2.create_tags([instance.id], {
         "Owner":            current_user.email,
         "Name":             request.form['name'],
-        "Application":      app.config['INSTANCE_APP_TAG']
+        "Application":      app.config['INSTANCE_APP_TAG'],
+        "App":              app.config['ACCOUNTING_APP_TAG'],
+        "Type":             app.config['ACCOUNTING_TYPE_TAG']
     })
 
     # Send an email to the user who launched it
@@ -1028,7 +1030,9 @@ def cluster_spawn():
     emr.add_tags(jobflow_id, {
         "Owner": current_user.email,
         "Name": request.form['name'],
-        "Application": app.config['INSTANCE_APP_TAG']
+        "Application": app.config['INSTANCE_APP_TAG'],
+        "App": app.config['ACCOUNTING_APP_TAG'],
+        "Type": app.config['ACCOUNTING_TYPE_TAG']
     })
 
     # Send an email to the user who launched it


### PR DESCRIPTION
Our current cost / accounting overview for EC2 uses "App" and "Type" tags.