### PR TITLE
Add SRI and security headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ histogram_cache/
 http/analysis-service/analysis-resources.json
 http/analysis-service/analysis-service-stack.json
 http/analysis-service/telemetry-analysis-service.tar.gz
+http/analysis-service/csp_violations.log
 node_modules/
 htmlcov/
 histogram_tools.py

--- a/http/analysis-service/analysis-service-stack.yaml
+++ b/http/analysis-service/analysis-service-stack.yaml
@@ -269,6 +269,7 @@ Resources:
               "echo '        add_header X-Frame-Options \"DENY\"' >> /etc/nginx/sites-enabled/default\n",
               "echo '        add_header Cache-Control \"no-cache,no-store\"' >> /etc/nginx/sites-enabled/default\n",
               "echo '        add_header Pragma \"no-cache\"' >> /etc/nginx/sites-enabled/default\n",
+              "echo '        add_header Content-Security-Policy-Report-Only \"style-src 'self' https://netdna.bootstrapcdn.com 'unsafe-inline'; report-uri /csp_report; default-src 'none'; script-src 'self' https://login.persona.org https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.11.1/jquery.validate.min.js; img-src 'self';  child-src https://login.persona.org; font-src https://netdna.bootstrapcdn.com; base-uri 'none'\"' >> /etc/nginx/sites-enabled/default\n",
               "echo '}' >> /etc/nginx/sites-enabled/default\n",
               "service nginx restart\n",
               "sudo -u ubuntu uwsgi --chmod-socket=666 -s /tmp/uwsgi.sock --logto /tmp/analysis-service.log -w server:app\n"

--- a/http/analysis-service/analysis-service-stack.yaml
+++ b/http/analysis-service/analysis-service-stack.yaml
@@ -267,6 +267,8 @@ Resources:
               "echo '        add_header X-XSS-Protection \"1; mode=block\"' >> /etc/nginx/sites-enabled/default\n",
               "echo '        add_header X-Content-Type-Options \"nosniff\"' >> /etc/nginx/sites-enabled/default\n",
               "echo '        add_header X-Frame-Options \"DENY\"' >> /etc/nginx/sites-enabled/default\n",
+              "echo '        add_header Cache-Control \"no-cache,no-store\"' >> /etc/nginx/sites-enabled/default\n",
+              "echo '        add_header Pragma \"no-cache\"' >> /etc/nginx/sites-enabled/default\n",
               "echo '}' >> /etc/nginx/sites-enabled/default\n",
               "service nginx restart\n",
               "sudo -u ubuntu uwsgi --chmod-socket=666 -s /tmp/uwsgi.sock --logto /tmp/analysis-service.log -w server:app\n"

--- a/http/analysis-service/analysis-service-stack.yaml
+++ b/http/analysis-service/analysis-service-stack.yaml
@@ -264,6 +264,9 @@ Resources:
               "echo '                include uwsgi_params;' >> /etc/nginx/sites-enabled/default\n",
               "echo '                uwsgi_pass unix:/tmp/uwsgi.sock;' >> /etc/nginx/sites-enabled/default\n",
               "echo '        }' >> /etc/nginx/sites-enabled/default\n",
+              "echo '        add_header X-XSS-Protection \"1; mode=block\"' >> /etc/nginx/sites-enabled/default\n",
+              "echo '        add_header X-Content-Type-Options \"nosniff\"' >> /etc/nginx/sites-enabled/default\n",
+              "echo '        add_header X-Frame-Options \"DENY\"' >> /etc/nginx/sites-enabled/default\n",
               "echo '}' >> /etc/nginx/sites-enabled/default\n",
               "service nginx restart\n",
               "sudo -u ubuntu uwsgi --chmod-socket=666 -s /tmp/uwsgi.sock --logto /tmp/analysis-service.log -w server:app\n"

--- a/http/analysis-service/makefile
+++ b/http/analysis-service/makefile
@@ -7,7 +7,8 @@ FILES = $(shell find * -name "*.py") \
 		$(shell find * -name "*.sh") \
 		$(shell find * -name "*.css") \
 		$(shell find * -name "*.png") \
-		$(shell find * -name "*.html")
+		$(shell find * -name "*.html") \
+		$(shell find static -name "*.js")
 
 telemetry-analysis-service.tar.gz: $(FILES)
 	tar -czf $@ $^

--- a/http/analysis-service/requirements
+++ b/http/analysis-service/requirements
@@ -4,7 +4,6 @@ docutils==0.12
 Flask==0.10.1
 Flask-BrowserID==0.0.4
 Flask-Login==0.3.2
-flask-csp==0.9
 futures==2.2.0
 itsdangerous==0.24
 Jinja2==2.8

--- a/http/analysis-service/requirements
+++ b/http/analysis-service/requirements
@@ -4,6 +4,7 @@ docutils==0.12
 Flask==0.10.1
 Flask-BrowserID==0.0.4
 Flask-Login==0.3.2
+flask-csp==0.9
 futures==2.2.0
 itsdangerous==0.24
 Jinja2==2.8

--- a/http/analysis-service/server.py
+++ b/http/analysis-service/server.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser
 from flask import Flask, render_template, g, request, redirect, url_for
 from flask.ext.login import LoginManager, login_required, current_user
 from flask.ext.browserid import BrowserID
+from flask_csp.csp import csp_default, csp_header
 from user import User, AnonymousUser
 from boto.emr import connect_to_region as emr_connect, BootstrapAction
 from boto.ec2 import connect_to_region as ec2_connect
@@ -24,6 +25,7 @@ import crontab
 import json
 import re
 import os.path
+import logging
 
 # Create flask app
 app = Flask(__name__)
@@ -51,6 +53,20 @@ CRON_IDX_DOM  = 2
 CRON_IDX_MON  = 3
 CRON_IDX_DOW  = 4
 CRON_IDX_CMD  = 5
+
+# Set default Content Security Policy
+csp_default().update({
+    "base-uri": "'none'",
+    "child-src" : "https://login.persona.org",
+    "default-src" : "'none'",
+    "img-src": "'self'",
+    "font-src": "https://netdna.bootstrapcdn.com",
+    "script-src": "'self' https://login.persona.org https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.11.1/jquery.validate.min.js",
+    "style-src": "'self' https://netdna.bootstrapcdn.com 'unsafe-inline'",
+    "report-uri": "/csp_report",
+    "report-only": True
+})
+
 
 def connect_db(db_url=None):
     if db_url is None:
@@ -776,10 +792,12 @@ def _view_job_data(is_cluster, job_id):
 
 # Routes
 @app.route('/', methods=["GET"])
+@csp_header()
 def index():
     return render_template('index.html')
 
 @app.route("/schedule", methods=["GET"])
+@csp_header()
 @login_required
 def schedule_job(errors=None, values=None):
     return _schedule_job(is_cluster=False, errors=errors, values=values)
@@ -790,26 +808,31 @@ def create_scheduled_job():
     return _create_scheduled_job(is_cluster=False)
 
 @app.route("/schedule/edit/<job_id>", methods=["GET","POST"])
+@csp_header()
 @login_required
 def edit_scheduled_job(job_id):
     return _edit_scheduled_job(is_cluster=False, job_id=job_id)
 
 @app.route("/schedule/delete/<job_id>", methods=["POST","GET","DELETE"])
+@csp_header()
 @login_required
 def delete_scheduled_job(job_id):
     return _delete_scheduled_job(is_cluster=False, job_id=job_id)
 
 @app.route("/schedule/logs/<job_id>", methods=["GET"])
+@csp_header()
 @login_required
 def view_job_logs(job_id):
     return _view_job_logs(is_cluster=False, job_id=job_id)
 
 @app.route("/schedule/data/<job_id>", methods=["GET"])
+@csp_header()
 @login_required
 def view_job_data(job_id):
     return _view_job_data(is_cluster=False, job_id=job_id)
 
 @app.route("/worker", methods=["GET"])
+@csp_header()
 @login_required
 def get_worker_params(errors=None, values=None):
     # Check that the user logged in is also authorized to do this
@@ -902,6 +925,7 @@ def spawn_worker_instance():
     return redirect(url_for('monitor', instance_id = instance.id))
 
 @app.route("/worker/monitor/<instance_id>", methods=["GET"])
+@csp_header()
 @login_required
 def monitor(instance_id):
     # Check that the user logged in is also authorized to do this
@@ -934,6 +958,7 @@ def monitor(instance_id):
     )
 
 @app.route("/worker/kill/<instance_id>", methods=["GET"])
+@csp_header()
 @login_required
 def kill(instance_id):
     # Check that the user logged in is also authorized to do this
@@ -965,6 +990,7 @@ def kill(instance_id):
     )
 
 @app.route("/cluster", methods=["GET"])
+@csp_header()
 @login_required
 def cluster_get_params(errors=None, values=None):
     # Check that the user logged in is also authorized to do this
@@ -1050,6 +1076,7 @@ def cluster_spawn():
     return redirect(url_for('cluster_monitor', jobflow_id = jobflow_id))
 
 @app.route("/cluster/monitor/<jobflow_id>", methods=["GET"])
+@csp_header()
 @login_required
 def cluster_monitor(jobflow_id):
     # Check that the user logged in is also authorized to do this
@@ -1080,6 +1107,7 @@ def cluster_monitor(jobflow_id):
     )
 
 @app.route("/cluster/kill/<jobflow_id>", methods=["GET"])
+@csp_header()
 @login_required
 def cluster_kill(jobflow_id):
     # Check that the user logged in is also authorized to do this
@@ -1106,6 +1134,7 @@ def cluster_kill(jobflow_id):
     )
 
 @app.route("/cluster/schedule", methods=["GET"])
+@csp_header()
 @login_required
 def cluster_schedule_job(errors=None, values=None):
     return _schedule_job(is_cluster=True, errors=errors, values=values)
@@ -1116,27 +1145,37 @@ def cluster_create_scheduled_job():
     return _create_scheduled_job(is_cluster=True)
 
 @app.route("/cluster/schedule/edit/<job_id>", methods=["GET","POST"])
+@csp_header()
 @login_required
 def cluster_edit_scheduled_job(job_id):
     return _edit_scheduled_job(is_cluster=True, job_id=job_id)
 
 @app.route("/cluster/schedule/delete/<job_id>", methods=["POST","GET","DELETE"])
+@csp_header()
 @login_required
 def cluster_delete_scheduled_job(job_id):
     return _delete_scheduled_job(is_cluster=True, job_id=job_id)
 
 @app.route("/cluster/schedule/logs/<job_id>", methods=["GET"])
+@csp_header()
 @login_required
 def cluster_view_job_logs(job_id):
     return _view_job_logs(is_cluster=True, job_id=job_id)
 
 @app.route("/cluster/schedule/data/<job_id>", methods=["GET"])
+@csp_header()
 @login_required
 def cluster_view_job_data(job_id):
     return _view_job_data(is_cluster=True, job_id=job_id)
 
 @app.route("/status", methods=["GET"])
+@csp_header()
 def status():
+    return "OK"
+
+@app.route("/csp_report", methods=["POST"])
+def csp_report():
+    csp_logger.warn(request.data)
     return "OK"
 
 login_manager.init_app(app)
@@ -1147,7 +1186,13 @@ if __name__ == '__main__':
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", default=80, type=int)
     parser.add_argument("--db-url", default='sqlite:///telemetry_analysis.db')
+    parser.add_argument("--csp-error-log", default='./csp_violations.log')
     args = parser.parse_args()
+
+    # Setup CSP report violation logger
+    csp_logger = logging.getLogger('csp_logger')
+    csp_logger.setLevel(logging.WARN)
+    csp_logger.addHandler(logging.FileHandler(args.csp_error_log))
 
     app.config.update(dict(
         DB_URL = args.db_url,

--- a/http/analysis-service/server.py
+++ b/http/analysis-service/server.py
@@ -4,7 +4,6 @@ from argparse import ArgumentParser
 from flask import Flask, render_template, g, request, redirect, url_for
 from flask.ext.login import LoginManager, login_required, current_user
 from flask.ext.browserid import BrowserID
-from flask_csp.csp import csp_default, csp_header
 from user import User, AnonymousUser
 from boto.emr import connect_to_region as emr_connect, BootstrapAction
 from boto.ec2 import connect_to_region as ec2_connect
@@ -53,20 +52,6 @@ CRON_IDX_DOM  = 2
 CRON_IDX_MON  = 3
 CRON_IDX_DOW  = 4
 CRON_IDX_CMD  = 5
-
-# Set default Content Security Policy
-csp_default().update({
-    "base-uri": "'none'",
-    "child-src" : "https://login.persona.org",
-    "default-src" : "'none'",
-    "img-src": "'self'",
-    "font-src": "https://netdna.bootstrapcdn.com",
-    "script-src": "'self' https://login.persona.org https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.11.1/jquery.validate.min.js",
-    "style-src": "'self' https://netdna.bootstrapcdn.com 'unsafe-inline'",
-    "report-uri": "/csp_report",
-    "report-only": True
-})
-
 
 def connect_db(db_url=None):
     if db_url is None:
@@ -792,12 +777,10 @@ def _view_job_data(is_cluster, job_id):
 
 # Routes
 @app.route('/', methods=["GET"])
-@csp_header()
 def index():
     return render_template('index.html')
 
 @app.route("/schedule", methods=["GET"])
-@csp_header()
 @login_required
 def schedule_job(errors=None, values=None):
     return _schedule_job(is_cluster=False, errors=errors, values=values)
@@ -808,31 +791,26 @@ def create_scheduled_job():
     return _create_scheduled_job(is_cluster=False)
 
 @app.route("/schedule/edit/<job_id>", methods=["GET","POST"])
-@csp_header()
 @login_required
 def edit_scheduled_job(job_id):
     return _edit_scheduled_job(is_cluster=False, job_id=job_id)
 
 @app.route("/schedule/delete/<job_id>", methods=["POST","GET","DELETE"])
-@csp_header()
 @login_required
 def delete_scheduled_job(job_id):
     return _delete_scheduled_job(is_cluster=False, job_id=job_id)
 
 @app.route("/schedule/logs/<job_id>", methods=["GET"])
-@csp_header()
 @login_required
 def view_job_logs(job_id):
     return _view_job_logs(is_cluster=False, job_id=job_id)
 
 @app.route("/schedule/data/<job_id>", methods=["GET"])
-@csp_header()
 @login_required
 def view_job_data(job_id):
     return _view_job_data(is_cluster=False, job_id=job_id)
 
 @app.route("/worker", methods=["GET"])
-@csp_header()
 @login_required
 def get_worker_params(errors=None, values=None):
     # Check that the user logged in is also authorized to do this
@@ -925,7 +903,6 @@ def spawn_worker_instance():
     return redirect(url_for('monitor', instance_id = instance.id))
 
 @app.route("/worker/monitor/<instance_id>", methods=["GET"])
-@csp_header()
 @login_required
 def monitor(instance_id):
     # Check that the user logged in is also authorized to do this
@@ -958,7 +935,6 @@ def monitor(instance_id):
     )
 
 @app.route("/worker/kill/<instance_id>", methods=["GET"])
-@csp_header()
 @login_required
 def kill(instance_id):
     # Check that the user logged in is also authorized to do this
@@ -990,7 +966,6 @@ def kill(instance_id):
     )
 
 @app.route("/cluster", methods=["GET"])
-@csp_header()
 @login_required
 def cluster_get_params(errors=None, values=None):
     # Check that the user logged in is also authorized to do this
@@ -1076,7 +1051,6 @@ def cluster_spawn():
     return redirect(url_for('cluster_monitor', jobflow_id = jobflow_id))
 
 @app.route("/cluster/monitor/<jobflow_id>", methods=["GET"])
-@csp_header()
 @login_required
 def cluster_monitor(jobflow_id):
     # Check that the user logged in is also authorized to do this
@@ -1107,7 +1081,6 @@ def cluster_monitor(jobflow_id):
     )
 
 @app.route("/cluster/kill/<jobflow_id>", methods=["GET"])
-@csp_header()
 @login_required
 def cluster_kill(jobflow_id):
     # Check that the user logged in is also authorized to do this
@@ -1134,7 +1107,6 @@ def cluster_kill(jobflow_id):
     )
 
 @app.route("/cluster/schedule", methods=["GET"])
-@csp_header()
 @login_required
 def cluster_schedule_job(errors=None, values=None):
     return _schedule_job(is_cluster=True, errors=errors, values=values)
@@ -1145,31 +1117,26 @@ def cluster_create_scheduled_job():
     return _create_scheduled_job(is_cluster=True)
 
 @app.route("/cluster/schedule/edit/<job_id>", methods=["GET","POST"])
-@csp_header()
 @login_required
 def cluster_edit_scheduled_job(job_id):
     return _edit_scheduled_job(is_cluster=True, job_id=job_id)
 
 @app.route("/cluster/schedule/delete/<job_id>", methods=["POST","GET","DELETE"])
-@csp_header()
 @login_required
 def cluster_delete_scheduled_job(job_id):
     return _delete_scheduled_job(is_cluster=True, job_id=job_id)
 
 @app.route("/cluster/schedule/logs/<job_id>", methods=["GET"])
-@csp_header()
 @login_required
 def cluster_view_job_logs(job_id):
     return _view_job_logs(is_cluster=True, job_id=job_id)
 
 @app.route("/cluster/schedule/data/<job_id>", methods=["GET"])
-@csp_header()
 @login_required
 def cluster_view_job_data(job_id):
     return _view_job_data(is_cluster=True, job_id=job_id)
 
 @app.route("/status", methods=["GET"])
-@csp_header()
 def status():
     return "OK"
 

--- a/http/analysis-service/static/auth_script.js
+++ b/http/analysis-service/static/auth_script.js
@@ -1,0 +1,45 @@
+$(function() {
+  var gotAssertion, logoutCallback, loginURL, logoutURL;
+
+  gotAssertion = function(assertion) {
+    if (assertion) {
+      return $.ajax({
+        type: 'POST',
+        url: '/api/login',
+        data: {
+          assertion: assertion
+        },
+        success: function(res, status, xhr) {
+          return location.reload(true);
+        },
+        error: function(res, status, xhr) {
+          return alert("login failure: " + status);
+        }
+      });
+    }
+  };
+  logoutCallback = function(event) {
+    $.ajax({
+      type: 'POST',
+      url: '/api/logout',
+      success: function() {
+        return location.reload(true);
+      },
+      error: function(res, status, xhr) {
+        console.log(res);
+        return alert("logout failure: " + status);
+      }
+    });
+    return false;
+  };
+  return $(function() {
+    $('#browserid-login').click(function() {
+      navigator.id.get(gotAssertion);
+      return false;
+    });
+    $('#browserid-logout').click(function() {
+      navigator.id.logout(logoutCallback);
+      return false;
+    });
+  });
+});

--- a/http/analysis-service/static/set_utcnow.js
+++ b/http/analysis-service/static/set_utcnow.js
@@ -1,0 +1,10 @@
+$(document).ready(function() {
+  var d = new Date();
+  var h = d.getUTCHours();
+  var m = d.getUTCMinutes();
+  var ampm = h >= 12 ? 'pm' : 'am';
+  h = h % 12;
+  if (h == 0) h = 12;
+  var utc_string = h + ':' + (m < 10 ? '0' : '') + m + ampm;
+  $('#utcnow').html(utc_string);
+});

--- a/http/analysis-service/templates/base.html
+++ b/http/analysis-service/templates/base.html
@@ -22,18 +22,7 @@
    <script src="https://login.persona.org/include.js" type="text/javascript"></script>
 
    <script type="text/javascript">{{ auth_script|safe }}</script>
-   <script type="text/javascript">
-    $(document).ready(function() {
-     var d = new Date();
-     var h = d.getUTCHours();
-     var m = d.getUTCMinutes();
-     var ampm = h >= 12 ? 'pm' : 'am';
-     h = h % 12;
-     if (h == 0) h = 12;
-     var utc_string = h + ':' + (m < 10 ? '0' : '') + m + ampm;
-     $('#utcnow').html(utc_string);
-    });
-   </script>
+   <script src="{{ url_for('static', filename='set_utcnow.js') }}"></script>
    <title>Telemetry Self-Serve Data Analysis</title>
   {% endblock %}
  </head>

--- a/http/analysis-service/templates/base.html
+++ b/http/analysis-service/templates/base.html
@@ -21,7 +21,7 @@
    <!-- Persona -->
    <script src="https://login.persona.org/include.js" type="text/javascript"></script>
 
-   <script type="text/javascript">{{ auth_script|safe }}</script>
+   <script src="{{ url_for('static', filename='auth_script.js') }}"></script>
    <script src="{{ url_for('static', filename='set_utcnow.js') }}"></script>
    <title>Telemetry Self-Serve Data Analysis</title>
   {% endblock %}

--- a/http/analysis-service/templates/base.html
+++ b/http/analysis-service/templates/base.html
@@ -14,7 +14,9 @@
    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"
            integrity="sha384-SDFvKZaD/OapoAVqhWJM8vThqq+NQWczamziIoxiMYVNrVeUUrf2zhbsFvuHOrAh"
            crossorigin="anonymous"></script>
-   <script type="text/javascript" src="//ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.11.1/jquery.validate.min.js"
+           integrity="sha384-B1miHxuCmAMGc0405Cm/zSXCc38EP5hNOy2bblqF6yiX01Svinm1mWMwJDdNDBGr"
+           crossorigin="anonymous"></script>
 
    <!-- Persona -->
    <script src="https://login.persona.org/include.js" type="text/javascript"></script>

--- a/http/analysis-service/templates/base.html
+++ b/http/analysis-service/templates/base.html
@@ -5,7 +5,10 @@
    <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet" />
 
    <!-- Bootstrap core CSS -->
-   <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+   <link rel="stylesheet"
+         href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"
+         integrity="sha384-7tY7Dc2Q8WQTKGz2Fa0vC4dWQo07N4mJjKvHfIGnxuC4vPqFGFQppd9b3NWpf18/"
+         crossorigin="anonymous">
 
    <!-- jQuery -->
    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>

--- a/http/analysis-service/templates/base.html
+++ b/http/analysis-service/templates/base.html
@@ -11,7 +11,9 @@
          crossorigin="anonymous">
 
    <!-- jQuery -->
-   <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"
+           integrity="sha384-SDFvKZaD/OapoAVqhWJM8vThqq+NQWczamziIoxiMYVNrVeUUrf2zhbsFvuHOrAh"
+           crossorigin="anonymous"></script>
    <script type="text/javascript" src="//ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
 
    <!-- Persona -->


### PR DESCRIPTION
TODO / need help with:
- [ ] test the nginx config (the CSP header was tested using flask-csp but the other weren't)
- [ ] find out where to log CSP violations

Changes to analysis-service:
* Add [subresource integrity/SRI](https://w3c.github.io/webappsec-subresource-integrity/) hashes to 3rd party JS scripts 
  * excluding Persona include.js which we trust with auth (adding a SRI hash with `crossorigin` set to `anonymous` or `use-credentials` causes the error `Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://login.persona.org/include.js. (Reason: CORS header ‘Access-Control-Allow-Origin’ does not match ‘https://login.persona.org’).`)
  * changed the CDN from `ajax.aspnetcdn.com` to `cdnjs.cloudflare.com`
* Add a report only CSP header
  * need `unsafe-line` for style-src until we can upgrade jQuery see also: https://github.com/toolness/fleeting/issues/9
  * Persona makes an iframe for communication
* Move inline JS to separate files so we don't need `unsafe-line` scripts 
  * this will require manually updating the Flask-BrowserID `auth_script` template variable if it changes
* Add older security headers for XSS protection, frame options, and content-type, and [cache control](https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching)
  * assuming the site isn't iframed someplace else

Functional Tests checking for CSP violations and other errors (after stubbing out the AWS resources):

- [x] GET /
- [x] log in w/ Persona
- [x] GET /cluster
- [x] GET cluster/monitor/test-cluster-id
- [x] GET /cluster/schedule
- [x] GET /worker
- [x] GET /schedule
- [x] log out w/ Persona
- [x] modify the version of a resource with an SRI hash and check that it causes an error